### PR TITLE
fix: Close #24. Fix PostgreSQL IntegrityError in add_policies

### DIFF
--- a/fastapi_user_auth/utils/sqlachemy_adapter.py
+++ b/fastapi_user_auth/utils/sqlachemy_adapter.py
@@ -147,7 +147,7 @@ class Adapter(BaseAdapter, UpdateAdapter):
         """adds a policy rules to the storage."""
         values = []
         for rule in rules:
-            values.append(self.parse_rule(ptype, rule).dict())
+            values.append(self.parse_rule(ptype, rule).dict(exclude={"id"}))
         if not values:
             return
         await self.db.async_execute(insert(self._db_class).values(values))


### PR DESCRIPTION
When using PostgreSQL, an error occurred when creating casbin rules due to the "id": None parameter in the database request.

This PR closes #24.